### PR TITLE
Use systemd on CentOS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
-# myface
-
-Installs and configures myface
+something something


### PR DESCRIPTION
Add new attribute for the init system. The user must set this on CentOS 7 since the sys-v script doesn't work there. This won't work on Ubuntu so users shouldn't set it there.